### PR TITLE
Fix off by one error in extract()

### DIFF
--- a/examples/build_captchas.rs
+++ b/examples/build_captchas.rs
@@ -1,7 +1,7 @@
 extern crate captcha;
 
-use captcha::{Captcha, Geometry};
 use captcha::filters::{Cow, Noise, Wave};
+use captcha::{Captcha, Geometry};
 
 use std::path::Path;
 
@@ -11,10 +11,14 @@ fn main() {
         .apply_filter(Noise::new(0.2))
         .apply_filter(Wave::new(2.0, 20.0))
         .view(220, 120)
-        .apply_filter(Cow::new().min_radius(40).max_radius(50).circles(1).area(Geometry::new(40, 150, 50, 70)))
-//        .apply_filter(Cow::new().min_radius(20).max_radius(30).circles(1).area(Geometry::new(50, 80, 30, 80)))
+        .apply_filter(
+            Cow::new()
+                .min_radius(40)
+                .max_radius(50)
+                .circles(1)
+                .area(Geometry::new(40, 150, 50, 70)),
+        )
+        //        .apply_filter(Cow::new().min_radius(20).max_radius(30).circles(1).area(Geometry::new(50, 80, 30, 80)))
         .save(Path::new("captcha.png"))
         .expect("save failed");
-
-
 }

--- a/examples/captcha.rs
+++ b/examples/captcha.rs
@@ -1,22 +1,46 @@
 extern crate captcha;
 
-use captcha::{gen, by_name, Difficulty, CaptchaName};
+use captcha::{by_name, gen, CaptchaName, Difficulty};
 use std::path::Path;
 
 fn main() {
-    gen(Difficulty::Easy).save(Path::new("captcha_random_easy.png")).expect("save failed");
-    gen(Difficulty::Medium).save(Path::new("captcha_random_medium.png")).expect("save failed");
-    gen(Difficulty::Hard).save(Path::new("captcha_random_hard.png")).expect("save failed");
+    gen(Difficulty::Easy)
+        .save(Path::new("captcha_random_easy.png"))
+        .expect("save failed");
+    gen(Difficulty::Medium)
+        .save(Path::new("captcha_random_medium.png"))
+        .expect("save failed");
+    gen(Difficulty::Hard)
+        .save(Path::new("captcha_random_hard.png"))
+        .expect("save failed");
 
-    by_name(Difficulty::Easy, CaptchaName::Amelia).save(Path::new("captcha_amelia_easy.png")).unwrap();
-    by_name(Difficulty::Medium, CaptchaName::Amelia).save(Path::new("captcha_amelia_medium.png")).unwrap();
-    by_name(Difficulty::Hard, CaptchaName::Amelia).save(Path::new("captcha_amelia_hard.png")).unwrap();
+    by_name(Difficulty::Easy, CaptchaName::Amelia)
+        .save(Path::new("captcha_amelia_easy.png"))
+        .unwrap();
+    by_name(Difficulty::Medium, CaptchaName::Amelia)
+        .save(Path::new("captcha_amelia_medium.png"))
+        .unwrap();
+    by_name(Difficulty::Hard, CaptchaName::Amelia)
+        .save(Path::new("captcha_amelia_hard.png"))
+        .unwrap();
 
-    by_name(Difficulty::Easy, CaptchaName::Lucy).save(Path::new("captcha_lucy_easy.png")).unwrap();
-    by_name(Difficulty::Medium, CaptchaName::Lucy).save(Path::new("captcha_lucy_medium.png")).unwrap();
-    by_name(Difficulty::Hard, CaptchaName::Lucy).save(Path::new("captcha_lucy_hard.png")).unwrap();
+    by_name(Difficulty::Easy, CaptchaName::Lucy)
+        .save(Path::new("captcha_lucy_easy.png"))
+        .unwrap();
+    by_name(Difficulty::Medium, CaptchaName::Lucy)
+        .save(Path::new("captcha_lucy_medium.png"))
+        .unwrap();
+    by_name(Difficulty::Hard, CaptchaName::Lucy)
+        .save(Path::new("captcha_lucy_hard.png"))
+        .unwrap();
 
-    by_name(Difficulty::Easy, CaptchaName::Mila).save(Path::new("captcha_mila_easy.png")).unwrap();
-    by_name(Difficulty::Medium, CaptchaName::Mila).save(Path::new("captcha_mila_medium.png")).unwrap();
-    by_name(Difficulty::Hard, CaptchaName::Mila).save(Path::new("captcha_mila_hard.png")).unwrap();
+    by_name(Difficulty::Easy, CaptchaName::Mila)
+        .save(Path::new("captcha_mila_easy.png"))
+        .unwrap();
+    by_name(Difficulty::Medium, CaptchaName::Mila)
+        .save(Path::new("captcha_mila_medium.png"))
+        .unwrap();
+    by_name(Difficulty::Hard, CaptchaName::Mila)
+        .save(Path::new("captcha_mila_hard.png"))
+        .unwrap();
 }

--- a/examples/perf.rs
+++ b/examples/perf.rs
@@ -2,8 +2,8 @@ extern crate captcha;
 extern crate time;
 
 use captcha::{gen, Difficulty};
-use time::PreciseTime;
 use std::thread;
+use time::PreciseTime;
 
 fn main() {
     let n = 500;

--- a/src/filters/cow.rs
+++ b/src/filters/cow.rs
@@ -1,9 +1,9 @@
 use rand::{thread_rng, Rng};
-use std::cmp::{min, max};
+use std::cmp::{max, min};
 use std::collections::BTreeSet;
 
-use images::Image;
 use filters::Filter;
+use images::Image;
 use Geometry;
 
 pub struct Cow {
@@ -11,7 +11,7 @@ pub struct Cow {
     max_radius: u32,
     n: u32,
     allow_duplicates: bool,
-    geometry: Option<Geometry>
+    geometry: Option<Geometry>,
 }
 
 impl Cow {
@@ -21,25 +21,34 @@ impl Cow {
             max_radius: 20,
             n: 3,
             allow_duplicates: true,
-            geometry: None
+            geometry: None,
         }
     }
 
     pub fn circles(self, n: u32) -> Self {
-        Cow { n: n, .. self }
+        Cow { n: n, ..self }
     }
 
     pub fn min_radius(self, min_radius: u32) -> Self {
-        Cow { min_radius: min_radius, .. self }
+        Cow {
+            min_radius: min_radius,
+            ..self
+        }
     }
 
     pub fn max_radius(self, max_radius: u32) -> Self {
-        Cow { max_radius: max_radius, .. self }
+        Cow {
+            max_radius: max_radius,
+            ..self
+        }
     }
 
     // right + bottom = inclusive
     pub fn area(self, g: Geometry) -> Self {
-        Cow { geometry: Some(g), .. self }
+        Cow {
+            geometry: Some(g),
+            ..self
+        }
     }
 
     fn get_pixels(x: i32, y: i32, r: i32, i: &mut Image) -> Vec<(u32, u32)> {
@@ -76,14 +85,20 @@ impl Filter for Cow {
 
         let g = match self.geometry {
             Some(ref x) => x.clone(),
-            None        => Geometry::new(0, i.width() - 1, 0, i.height() - 1),
+            None => Geometry::new(0, i.width() - 1, 0, i.height() - 1),
         };
 
-        let mut pixels = vec![(rng.gen_range(g.left, g.right + 1), rng.gen_range(g.top, g.bottom + 1))];
+        let mut pixels = vec![(
+            rng.gen_range(g.left, g.right + 1),
+            rng.gen_range(g.top, g.bottom + 1),
+        )];
         let mut set = BTreeSet::new();
 
         for _ in 0..self.n {
-            let p = thread_rng().choose_mut(&mut pixels).expect("failed").clone();
+            let p = thread_rng()
+                .choose_mut(&mut pixels)
+                .expect("failed")
+                .clone();
 
             let r = rng.gen_range(self.min_radius, self.max_radius + 1) as i32;
             let v = Self::get_pixels(p.0 as i32, p.1 as i32, r, i);

--- a/src/filters/dots.rs
+++ b/src/filters/dots.rs
@@ -1,7 +1,7 @@
 use rand::{thread_rng, Rng};
 
-use images::{Image, Pixl};
 use filters::Filter;
+use images::{Image, Pixl};
 
 pub struct Dots {
     n: u32,
@@ -14,16 +14,22 @@ impl Dots {
         Dots {
             n: n,
             min_radius: 5,
-            max_radius: 10
+            max_radius: 10,
         }
     }
 
     pub fn min_radius(self, r: u32) -> Dots {
-        Dots { min_radius: r, .. self }
+        Dots {
+            min_radius: r,
+            ..self
+        }
     }
 
     pub fn max_radius(self, r: u32) -> Dots {
-        Dots { max_radius: r, .. self }
+        Dots {
+            max_radius: r,
+            ..self
+        }
     }
 }
 

--- a/src/filters/grid.rs
+++ b/src/filters/grid.rs
@@ -1,16 +1,16 @@
-use images::{Image, Pixl};
 use filters::Filter;
+use images::{Image, Pixl};
 
 pub struct Grid {
     y_gap: u32,
-    x_gap: u32
+    x_gap: u32,
 }
 
 impl Grid {
     pub fn new(x_gap: u32, y_gap: u32) -> Grid {
         Grid {
             x_gap: x_gap,
-            y_gap: y_gap
+            y_gap: y_gap,
         }
     }
 }

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -1,18 +1,18 @@
 //! Filters to disturb and transform CAPTCHAs.
 
-mod noise;
-mod grid;
 mod cow;
 mod dots;
+mod grid;
+mod noise;
 mod wave;
 
 use images::Image;
 
 // reexports
-pub use filters::noise::Noise;
-pub use filters::grid::Grid;
 pub use filters::cow::Cow;
 pub use filters::dots::Dots;
+pub use filters::grid::Grid;
+pub use filters::noise::Noise;
 pub use filters::wave::Wave;
 
 pub trait Filter {

--- a/src/filters/noise.rs
+++ b/src/filters/noise.rs
@@ -1,17 +1,15 @@
-use rand::{Rng, thread_rng};
+use rand::{thread_rng, Rng};
 
-use images::{Image, Pixl};
 use filters::Filter;
+use images::{Image, Pixl};
 
 pub struct Noise {
-    prob: f32
+    prob: f32,
 }
 
 impl Noise {
     pub fn new(prob: f32) -> Noise {
-        Noise {
-            prob: prob
-        }
+        Noise { prob: prob }
     }
 }
 

--- a/src/filters/wave.rs
+++ b/src/filters/wave.rs
@@ -1,11 +1,11 @@
 use std::f64::consts;
 
-use images::Image;
 use filters::Filter;
+use images::Image;
 
 pub enum Direction {
     HORIZONTAL,
-    VERTICAL
+    VERTICAL,
 }
 
 pub struct Wave {
@@ -24,15 +24,21 @@ impl Wave {
     }
 
     pub fn horizontal(self) -> Wave {
-        Wave { d: Direction::HORIZONTAL, .. self }
+        Wave {
+            d: Direction::HORIZONTAL,
+            ..self
+        }
     }
 
     pub fn vertical(self) -> Wave {
-        Wave { d: Direction::VERTICAL, .. self }
+        Wave {
+            d: Direction::VERTICAL,
+            ..self
+        }
     }
 
     pub fn direction(self, d: Direction) -> Wave {
-        Wave { d: d, .. self }
+        Wave { d: d, ..self }
     }
 }
 
@@ -46,7 +52,8 @@ impl Filter for Wave {
             Direction::HORIZONTAL => {
                 // height of image changes
                 for x in 0..i.width() {
-                    let f = (x as f64 * 2.0 * consts::PI * self.f / i.width() as f64).sin() * self.amp;
+                    let f =
+                        (x as f64 * 2.0 * consts::PI * self.f / i.width() as f64).sin() * self.amp;
                     for y in 0..i.height() {
                         let ny = y as i32 - f as i32;
                         if ny >= 0 && ny < i.height() as i32 {
@@ -54,10 +61,11 @@ impl Filter for Wave {
                         }
                     }
                 }
-            },
+            }
             Direction::VERTICAL => {
                 for y in 0..i.height() {
-                    let f = (y as f64 * 2.0 * consts::PI * self.f / i.width() as f64).sin() * self.amp;
+                    let f =
+                        (y as f64 * 2.0 * consts::PI * self.f / i.width() as f64).sin() * self.amp;
                     for x in 0..i.width() {
                         let nx = x as i32 - f as i32;
                         if nx >= 0 && nx < i.width() as i32 {

--- a/src/fonts/mod.rs
+++ b/src/fonts/mod.rs
@@ -1,6 +1,6 @@
+use base64::decode;
 use serde_json;
 use std::collections::HashMap;
-use base64::decode;
 
 pub trait Font {
     fn png_as_base64(&self, letter: char) -> Option<&String>;
@@ -10,19 +10,17 @@ pub trait Font {
     /// Returns None if letter does not exist or if letter could not decoded.
     fn png(&self, letter: char) -> Option<Vec<u8>> {
         match self.png_as_base64(letter) {
-            None    => None,
-            Some(s) => {
-                match decode(s) {
-                    Err(_) => None,
-                    Ok(v)  => Some(v)
-                }
-            }
+            None => None,
+            Some(s) => match decode(s) {
+                Err(_) => None,
+                Ok(v) => Some(v),
+            },
         }
     }
 }
 
 pub struct Default {
-    data: HashMap<char, String>
+    data: HashMap<char, String>,
 }
 
 impl Default {
@@ -30,7 +28,7 @@ impl Default {
         let json = include_str!("font_default.json").to_string();
 
         Default {
-            data: serde_json::from_str(&json).expect("invalid json")
+            data: serde_json::from_str(&json).expect("invalid json"),
         }
     }
 }
@@ -47,8 +45,8 @@ impl Font for Default {
 
 #[cfg(test)]
 mod tests {
-    use images::Image;
     use fonts::{Default, Font};
+    use images::Image;
 
     #[test]
     fn fonts_default() {

--- a/src/images/mod.rs
+++ b/src/images/mod.rs
@@ -1,14 +1,14 @@
+use std::cmp::{max, min};
 use std::io::Result;
-use std::path::Path;
-use std::cmp::{min, max};
 use std::iter::FromIterator;
+use std::path::Path;
 
-use image::{RgbImage, ImageBuffer, Rgb, load_from_memory};
+use image::{load_from_memory, ImageBuffer, Rgb, RgbImage};
 use lodepng;
 
 #[derive(Clone, Copy)]
 pub struct Pixl {
-    rgb: [u8; 3]
+    rgb: [u8; 3],
 }
 
 #[derive(Clone)]
@@ -18,9 +18,7 @@ pub struct Image {
 
 impl Pixl {
     pub fn new(r: u8, g: u8, b: u8) -> Pixl {
-        Pixl {
-            rgb: [r, g, b]
-        }
+        Pixl { rgb: [r, g, b] }
     }
 
     pub fn black() -> Pixl {
@@ -39,22 +37,20 @@ impl Pixl {
 }
 
 impl Image {
-    fn pixel_white() -> Rgb<u8> { Rgb::<u8>([255, 255, 255]) }
+    fn pixel_white() -> Rgb<u8> {
+        Rgb::<u8>([255, 255, 255])
+    }
 
     pub fn from_png(v: Vec<u8>) -> Option<Image> {
         match load_from_memory(&v) {
             Err(_) => None,
-            Ok(i)  => {
-                Some(Image {
-                    img: i.to_rgb()
-                })
-            }
+            Ok(i) => Some(Image { img: i.to_rgb() }),
         }
     }
 
     pub fn new(w: u32, h: u32) -> Image {
         Image {
-            img: ImageBuffer::from_pixel(w, h, Self::pixel_white())
+            img: ImageBuffer::from_pixel(w, h, Self::pixel_white()),
         }
     }
 
@@ -117,9 +113,7 @@ impl Image {
         let i = self.img.clone().into_raw();
         match lodepng::encode_memory(&i, w, h, lodepng::ColorType::LCT_RGB, 8) {
             Err(_) => None,
-            Ok(v)  => {
-                Some(Vec::from_iter(v.as_ref().iter().cloned()))
-            }
+            Ok(v) => Some(Vec::from_iter(v.as_ref().iter().cloned())),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,11 +204,11 @@ impl Captcha {
     pub fn extract(&mut self, area: Geometry) -> &mut Self {
         // TODO rename the method
         // TODO adjust the text area
-        let w = area.right - area.left + 1;
-        let h = area.bottom - area.top + 1;
+        let w = area.right - area.left;
+        let h = area.bottom - area.top;
         let mut i = Image::new(w, h);
-        for (y, iy) in (area.top..area.bottom + 1).zip(0..h + 1) {
-            for (x, ix) in (area.left..area.right + 1).zip(0..w + 1) {
+        for (y, iy) in (area.top..area.bottom).zip(0..h + 1) {
+            for (x, ix) in (area.left..area.right).zip(0..w + 1) {
                 i.put_pixel(ix, iy, self.img.get_pixel(x, y));
             }
         }
@@ -291,5 +291,13 @@ mod tests {
             .save(Path::new("/tmp/captcha.png"))
             .expect("save failed");
         c.as_png().expect("no png");
+    }
+
+    #[test]
+    fn image_size() {
+        let mut c = Captcha::new();
+        c.view(8, 16);
+        assert_eq!(&c.img.width(), &8);
+        assert_eq!(&c.img.height(), &16);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ impl Geometry {
 /// A CAPTCHA.
 pub struct Captcha {
     img: Image,
-    font: Box<Font>,
+    font: Box<dyn Font>,
     text_area: Geometry,
     chars: Vec<char>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,27 +47,27 @@
 // TODO resize characters
 // TODO overlap characters
 
+extern crate base64;
 extern crate image;
+extern crate lodepng;
 extern crate rand;
 extern crate serde_json;
-extern crate base64;
-extern crate lodepng;
 
 pub mod filters;
-mod samples;
-mod images;
 mod fonts;
+mod images;
+mod samples;
 
-pub use samples::{gen, by_name, Difficulty, CaptchaName};
+pub use samples::{by_name, gen, CaptchaName, Difficulty};
 
 use filters::Filter;
-use images::{Image, Pixl};
 use fonts::{Default, Font};
+use images::{Image, Pixl};
 
-use std::path::Path;
-use std::io::Result;
 use rand::{thread_rng, Rng};
-use std::cmp::{min, max};
+use std::cmp::{max, min};
+use std::io::Result;
+use std::path::Path;
 
 /// Represents the area which contains text in a CAPTCHA.
 #[derive(Clone, Debug)]
@@ -79,13 +79,16 @@ pub struct Geometry {
     /// The minimum y coordinate of the area which contains text (inclusive).
     pub top: u32,
     /// The maximum y coordinate of the area which contains text (inclusive).
-    pub bottom: u32
+    pub bottom: u32,
 }
 
 impl Geometry {
     pub fn new(left: u32, right: u32, top: u32, bottom: u32) -> Geometry {
         Geometry {
-            left: left, right: right, top: top, bottom: bottom
+            left: left,
+            right: right,
+            top: top,
+            bottom: bottom,
         }
     }
 }
@@ -95,7 +98,7 @@ pub struct Captcha {
     img: Image,
     font: Box<Font>,
     text_area: Geometry,
-    chars: Vec<char>
+    chars: Vec<char>,
 }
 
 impl Captcha {
@@ -105,10 +108,15 @@ impl Captcha {
         let w = 400;
         let h = 300;
         Captcha {
-            img      : Image::new(w, h),
-            font     : Box::new(Default::new()),
-            text_area: Geometry { left: w / 4, right: w / 4, top: h / 2, bottom: h / 2 },
-            chars    : vec![]
+            img: Image::new(w, h),
+            font: Box::new(Default::new()),
+            text_area: Geometry {
+                left: w / 4,
+                right: w / 4,
+                top: h / 2,
+                bottom: h / 2,
+            },
+            chars: vec![],
         }
     }
 
@@ -136,21 +144,21 @@ impl Captcha {
     ///
     /// The format that is written is determined from the filename's extension. On error `Err` is
     /// returned.
-    pub fn save(&self, p: &Path) -> Result<()> { self.img.save(p) }
+    pub fn save(&self, p: &Path) -> Result<()> {
+        self.img.save(p)
+    }
 
     fn random_char_as_image(&self) -> Option<(char, Image)> {
         let mut rng = thread_rng();
         match rng.choose(&self.font.chars()) {
-            None    => None,
-            Some(c) => {
-                match self.font.png(c.clone()) {
-                    None    => None,
-                    Some(p) => match Image::from_png(p) {
-                        None    => None,
-                        Some(i) => Some((c.clone(), i))
-                    }
-                }
-            }
+            None => None,
+            Some(c) => match self.font.png(c.clone()) {
+                None => None,
+                Some(p) => match Image::from_png(p) {
+                    None => None,
+                    Some(i) => Some((c.clone(), i)),
+                },
+            },
         }
     }
 
@@ -162,12 +170,12 @@ impl Captcha {
                 let y = (self.text_area.bottom + self.text_area.top) / 2 - i.height() / 2;
                 self.img.add_image(x, y, &i);
 
-                self.text_area.top    = min(self.text_area.top, y);
-                self.text_area.right  = x + i.width() - 1;
+                self.text_area.top = min(self.text_area.top, y);
+                self.text_area.right = x + i.width() - 1;
                 self.text_area.bottom = max(self.text_area.bottom, y + i.height() - 1);
                 self.chars.push(c);
-            },
-            _ => { }
+            }
+            _ => {}
         }
 
         self
@@ -212,9 +220,9 @@ impl Captcha {
     /// box.
     pub fn view(&mut self, w: u32, h: u32) -> &mut Self {
         let mut a = self.text_area();
-        a.left   = (a.right + a.left) / 2 - w / 2;
-        a.right  = a.left + w;
-        a.top    = (a.bottom + a.top) / 2 - h / 2;
+        a.left = (a.right + a.left) / 2 - w / 2;
+        a.right = a.left + w;
+        a.top = (a.bottom + a.top) / 2 - h / 2;
         a.bottom = a.top + h;
         self.extract(a);
         // TODO update text area
@@ -253,17 +261,17 @@ impl Captcha {
     /// Returns `None` on error.
     pub fn as_tuple(&self) -> Option<(String, Vec<u8>)> {
         match self.as_png() {
-            None    => None,
-            Some(p) => Some((self.chars_as_string(), p))
+            None => None,
+            Some(p) => Some((self.chars_as_string(), p)),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use Captcha;
-    use filters::{Noise, Grid};
+    use filters::{Grid, Noise};
     use fonts::Default;
+    use Captcha;
 
     use std::path::Path;
 
@@ -279,7 +287,9 @@ mod tests {
             .add_text_area();
 
         let a = c.text_area();
-        c.extract(a).save(Path::new("/tmp/captcha.png")).expect("save failed");
+        c.extract(a)
+            .save(Path::new("/tmp/captcha.png"))
+            .expect("save failed");
         c.as_png().expect("no png");
     }
 }

--- a/src/samples/mod.rs
+++ b/src/samples/mod.rs
@@ -13,9 +13,9 @@
 //! gen(Difficulty::Easy).as_png();
 //! # }
 //! ```
-use rand::{Rng, thread_rng};
-use {Geometry, Captcha};
-use filters::{Noise, Grid, Dots, Wave, Cow};
+use filters::{Cow, Dots, Grid, Noise, Wave};
+use rand::{thread_rng, Rng};
+use {Captcha, Geometry};
 
 const WIDTH: u32 = 220;
 const HEIGHT: u32 = 120;
@@ -24,7 +24,7 @@ const HEIGHT: u32 = 120;
 pub enum Difficulty {
     Easy,
     Medium,
-    Hard
+    Hard,
 }
 
 /// Names of predefined CAPTCHAs.
@@ -113,8 +113,8 @@ pub fn gen(d: Difficulty) -> Captcha {
 pub fn by_name(d: Difficulty, t: CaptchaName) -> Captcha {
     match t {
         CaptchaName::Amelia => captcha_amelia(d),
-        CaptchaName::Lucy   => captcha_lucy(d),
-        CaptchaName::Mila   => captcha_mila(d),
+        CaptchaName::Lucy => captcha_lucy(d),
+        CaptchaName::Mila => captcha_mila(d),
     }
 }
 
@@ -128,16 +128,22 @@ fn captcha_amelia(d: Difficulty) -> Captcha {
     let mut c = Captcha::new();
     c.add_chars(rnd());
     match d {
-        Difficulty::Easy   => c.apply_filter(Noise::new(0.2)).apply_filter(Grid::new(8, 8)),
-        Difficulty::Medium => c.apply_filter(Noise::new(0.3)).apply_filter(Grid::new(6, 6)),
-        Difficulty::Hard   => c.apply_filter(Noise::new(0.5)).apply_filter(Grid::new(4, 4))
+        Difficulty::Easy => c
+            .apply_filter(Noise::new(0.2))
+            .apply_filter(Grid::new(8, 8)),
+        Difficulty::Medium => c
+            .apply_filter(Noise::new(0.3))
+            .apply_filter(Grid::new(6, 6)),
+        Difficulty::Hard => c
+            .apply_filter(Noise::new(0.5))
+            .apply_filter(Grid::new(4, 4)),
     };
     c.apply_filter(Wave::new(2.0, 10.0)).view(WIDTH, HEIGHT);
     match d {
-        Difficulty::Easy   => c.apply_filter(Dots::new(10).max_radius(7).min_radius(3)),
+        Difficulty::Easy => c.apply_filter(Dots::new(10).max_radius(7).min_radius(3)),
         Difficulty::Medium => c.apply_filter(Dots::new(15).max_radius(7).min_radius(4)),
-        Difficulty::Hard   => c.apply_filter(Dots::new(20).max_radius(7).min_radius(5)),
-    } ;
+        Difficulty::Hard => c.apply_filter(Dots::new(20).max_radius(7).min_radius(5)),
+    };
     c
 }
 
@@ -145,14 +151,14 @@ fn captcha_lucy(d: Difficulty) -> Captcha {
     let (n, g) = match d {
         Difficulty::Easy => (0.1, 8),
         Difficulty::Medium => (0.4, 6),
-        Difficulty::Hard => (0.6, 4)
+        Difficulty::Hard => (0.6, 4),
     };
 
     let mut c = Captcha::new();
     c.add_chars(rnd())
-     .apply_filter(Noise::new(n))
-     .apply_filter(Grid::new(g, g))
-     .view(WIDTH, HEIGHT);
+        .apply_filter(Noise::new(n))
+        .apply_filter(Grid::new(g, g))
+        .view(WIDTH, HEIGHT);
     c
 }
 
@@ -160,13 +166,19 @@ fn captcha_mila(d: Difficulty) -> Captcha {
     let mut c = Captcha::new();
     c.add_chars(rnd());
     match d {
-        Difficulty::Easy   => c.apply_filter(Noise::new(0.2)),
+        Difficulty::Easy => c.apply_filter(Noise::new(0.2)),
         Difficulty::Medium => c.apply_filter(Noise::new(0.3)),
-        Difficulty::Hard   => c.apply_filter(Noise::new(0.5))
+        Difficulty::Hard => c.apply_filter(Noise::new(0.5)),
     };
     c.apply_filter(Wave::new(2.0, 20.0))
-     .view(WIDTH, HEIGHT)
-     .apply_filter(Cow::new().min_radius(40).max_radius(50).circles(1).area(Geometry::new(40, 150, 50, 70)));
+        .view(WIDTH, HEIGHT)
+        .apply_filter(
+            Cow::new()
+                .min_radius(40)
+                .max_radius(50)
+                .circles(1)
+                .area(Geometry::new(40, 150, 50, 70)),
+        );
     c
 }
 
@@ -180,5 +192,3 @@ fn captcha_mila(d: Difficulty) -> Captcha {
 //        .apply_filter(Dots::new(15));
 //    c
 //}
-
-


### PR DESCRIPTION
I noticed images were being generated 1 pixel too large in width and height. I think I tracked down the right place to make the change, but let me know if it should be handled another way.

The actual fix is in 6a2b1f64caacf875eecfab0f9767f97e19179718 and I'm happy to remove the `rustfmt` changes if you'd prefer.

How would you feel about changing this conditional to an `assert_eq!`?

```patch
     pub fn put_pixel(&mut self, x: u32, y: u32, p: Pixl) {
-        if x < self.img.width() && y < self.img.height() {
-            self.img.put_pixel(x, y, Rgb::<u8>(p.rgb));
-        }
+        assert!(x < self.img.width() && y < self.img.height());
+        self.img.put_pixel(x, y, Rgb::<u8>(p.rgb));
     }
```