### PR TITLE
Disable unused image features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/daniel-e/captcha"
 repository = "https://github.com/daniel-e/captcha"
 
 [dependencies]
-image = "0.23"
+image = { version = "0.23", default-features = false, features = ["png"] }
 rand = "0.7"
 serde_json = "1.0"
 base64 = "0.13"


### PR DESCRIPTION
For me this change reduces clean build time from 35s to 29s, about 20% faster. Measured with:
```bash
cargo clean
RUSTC_WRAPPER='' cargo +nightly build -Ztimings
```

The env var is to disable sccache in case you have that enabled. Open the generated html file for detailed stats.