### PR TITLE
Allow setting Rng

### DIFF
--- a/src/images/mod.rs
+++ b/src/images/mod.rs
@@ -43,7 +43,7 @@ impl Image {
     pub fn from_png(v: Vec<u8>) -> Option<Image> {
         match load_from_memory(&v) {
             Err(_) => None,
-            Ok(i) => Some(Image { img: i.to_rgb() }),
+            Ok(i) => Some(Image { img: i.to_rgb8() }),
         }
     }
 


### PR DESCRIPTION
This allows setting the random number generator. This is useful in environments where specific RNG features are required. In my case, I was running this code in a wasm environment where `thread_rng()` is not implemented/available.